### PR TITLE
Improve MAF algorithm and add check

### DIFF
--- a/extras/Filters/MAF.h
+++ b/extras/Filters/MAF.h
@@ -10,14 +10,18 @@ class MAF {
     public:
         // Constructor
         MAF(uint8_t Size) {
-            // Save array size
+            // Check and save array size
             buffer_size = Size > MAF_ARRAYSIZE ? MAF_ARRAYSIZE : Size;
 
-            // Bear in mind that data[N] array is defined in private
-            // but is not initialized.
-            // For some reason the implementation works, but in case you encounter
-            // "Weird behaviour", this is the place to look.
+            /* Bear in mind that data[N] array is defined in private
+               but is not initialized.
+               For some reason the implementation works, but in case you encounter
+               "Weird behaviour", this is the place to look.
             
+            for (uint8_t i = 0; i < buffer_size; i++) {
+                data[i] = 0;
+            }*/
+
             // Initialize head
             head = 0;
         };

--- a/extras/Filters/MAF.h
+++ b/extras/Filters/MAF.h
@@ -1,6 +1,6 @@
 /*  Moving Average Filter implementation
     Using ring buffer to store/swap between the received data.
-    SmoothFactor (passed as int to the constructor) can never be higher than
+    buffer_size (passed as int to the constructor) can never be higher than
     MAF_ARRAYSIZE constant.
 */
 
@@ -18,33 +18,30 @@ class MAF {
                For some reason the implementation works, but in case you encounter
                "Weird behaviour", this is the place to look.
             
+            // Initialize data
             for (uint8_t i = 0; i < buffer_size; i++) {
-                data[i] = 0;
+                data[i] = 0.0;
             }*/
+        }
 
-            // Initialize head
-            head = 0;
-        };
-    
-        double update(double value) {           
-            // Store new value inside the array
+        double update(double value) {
+            // Subtract oldest value from sum
+            sum -= data[head];
+            // Add newest value to sum
+            sum += value;
+            // Store new value inside the array (overwrite oldest)
             data[head] = value;
+
             head++;
-            
             // If we reached end of the array, return to beginning
             if (head == buffer_size) head = 0;
-            
-            double sum;
-            for (uint8_t i = 0; i < buffer_size; i++) {
-                sum += data[i];
-            }
-    
-            sum /= buffer_size;
-            return sum;
-        };
-        
+
+            return sum / buffer_size;
+        }
+
     private:
         uint8_t buffer_size;
         double data[MAF_ARRAYSIZE];
-        uint8_t head;
+        uint8_t head = 0;
+        double sum = 0.0;
 };

--- a/extras/Filters/MAF.h
+++ b/extras/Filters/MAF.h
@@ -1,6 +1,6 @@
 /*  Moving Average Filter implementation
     Using ring buffer to store/swap between the received data.
-    SmoothFactor (parsed as int to the constructor) can never be higher then
+    SmoothFactor (passed as int to the constructor) can never be higher than
     MAF_ARRAYSIZE constant.
 */
 
@@ -44,3 +44,4 @@ class MAF {
         double data[MAF_ARRAYSIZE];
         uint8_t head;
 };
+

--- a/extras/Filters/MAF.h
+++ b/extras/Filters/MAF.h
@@ -11,8 +11,8 @@ class MAF {
         // Constructor
         MAF(uint8_t Size) {
             // Save array size
-            smoothFactor = Size;
-            
+            smoothFactor = Size > MAF_ARRAYSIZE ? MAF_ARRAYSIZE : Size;
+
             // Bear in mind that data[N] array is defined in private
             // but is not initialized.
             // For some reason the implementation works, but in case you encounter
@@ -44,4 +44,3 @@ class MAF {
         double data[MAF_ARRAYSIZE];
         uint8_t head;
 };
-

--- a/extras/Filters/MAF.h
+++ b/extras/Filters/MAF.h
@@ -11,7 +11,7 @@ class MAF {
         // Constructor
         MAF(uint8_t Size) {
             // Save array size
-            smoothFactor = Size > MAF_ARRAYSIZE ? MAF_ARRAYSIZE : Size;
+            buffer_size = Size > MAF_ARRAYSIZE ? MAF_ARRAYSIZE : Size;
 
             // Bear in mind that data[N] array is defined in private
             // but is not initialized.
@@ -28,19 +28,19 @@ class MAF {
             head++;
             
             // If we reached end of the array, return to beginning
-            if (head == smoothFactor) head = 0;
+            if (head == buffer_size) head = 0;
             
             double sum;
-            for (uint8_t i = 0; i < smoothFactor; i++) {
+            for (uint8_t i = 0; i < buffer_size; i++) {
                 sum += data[i];
             }
     
-            sum /= smoothFactor;
+            sum /= buffer_size;
             return sum;
         };
         
     private:
-        uint8_t smoothFactor;
+        uint8_t buffer_size;
         double data[MAF_ARRAYSIZE];
         uint8_t head;
 };


### PR DESCRIPTION
I do not know whether you actually use this filter, but I stumbled upon it and did 2 minor fixes. 
* Previously, the constructor parameter wasn't checked. The comment on top states that the buffer size can never be larger than MAF_ARRAYSIZE but this wasn't actually checked.

* Less importantly, I speeded up the moving average calculation. For window sizes below 20 this didn't make a big difference, but for larger windows the new code still has roughly constant time while the old code takes more time with increasing buffer sizes. I wouldn't mind at all if you rejected this change, just let me know.